### PR TITLE
Require authenticated session for SOC API user resolution

### DIFF
--- a/apps/web/app/api/soc/_common.ts
+++ b/apps/web/app/api/soc/_common.ts
@@ -61,7 +61,6 @@ export async function resolveCurrentUser(
   client: SupabaseClient<Database>,
 ): Promise<{ userId: string; email?: string | null; name?: string | null }> {
   const session = await auth();
-  const headerUserId = request.headers.get('x-user-id');
 
   if (session?.user) {
     const maybeId = (session.user as { id?: string }).id;
@@ -89,10 +88,6 @@ export async function resolveCurrentUser(
         };
       }
     }
-  }
-
-  if (headerUserId) {
-    return { userId: headerUserId };
   }
 
   throw new HttpError(401, 'Authentication required');


### PR DESCRIPTION
## Summary
- require a verified NextAuth session when resolving the current SOC API user
- remove the unauthenticated x-user-id header fallback that allowed privilege escalation

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e558bc21cc8325bd681855f3d181ef