### PR TITLE
Add Sampling C1 integration for control testing

### DIFF
--- a/apps/web/lib/audit/sampling-client.ts
+++ b/apps/web/lib/audit/sampling-client.ts
@@ -145,7 +145,11 @@ export class SamplingClient {
 
 let cachedClient: SamplingClient | null = null;
 
-export function getSamplingClient(): SamplingClient {
+export function getSamplingClient(options?: SamplingClientOptions): SamplingClient {
+  if (options) {
+    return new SamplingClient(options);
+  }
+
   if (!cachedClient) {
     cachedClient = new SamplingClient({
       baseUrl: process.env.SAMPLING_C1_BASE_URL,


### PR DESCRIPTION
## Summary
- introduce a Sampling C1 client with deterministic fixtures and live mode normalization
- persist sampling results through the controls test run API and expose GET listings
- surface sampling statuses, retry actions, and sample plan links in the audit controls workspace
- document the new flow in the ITGC policy and update traceability records
- wire the controls test run sampling client to the configured Sampling C1 base URL so live mode requests resolve correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e558b814388325bd558df6264ea92b