### PR TITLE
fix: allow functional state updates in tax request helper

### DIFF
--- a/apps/web/app/tax/page.tsx
+++ b/apps/web/app/tax/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import type { CalculatorResult, ModuleKey, TaxActivity } from '../../lib/tax/types';
 import {
   assessFiscalUnity,
@@ -369,7 +370,7 @@ export default function Tax() {
   async function requestCalculation<TMetrics extends Record<string, unknown>>(
     url: string,
     payload: Record<string, unknown>,
-    setState: (value: ModuleState<TMetrics>) => void
+    setState: Dispatch<SetStateAction<ModuleState<TMetrics>>>
   ) {
     setState((previous) => ({ ...previous, loading: true, error: null }));
 


### PR DESCRIPTION
## Summary
- type the tax request helper's `setState` parameter as a React dispatch to permit functional state updates
- import the React dispatch utilities used by the helper signature

## Testing
- ⚠️ `pnpm lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e558af587c83259bf80b66d91cffc5