### PR TITLE
fix: replace noop semicolons in placeholder migrations

### DIFF
--- a/supabase/migrations/20250926090000_.sql
+++ b/supabase/migrations/20250926090000_.sql
@@ -1,1 +1,1 @@
-;
+-- noop migration placeholder for production deployment

--- a/supabase/migrations/20250926181500_.sql
+++ b/supabase/migrations/20250926181500_.sql
@@ -1,1 +1,1 @@
-;
+-- noop migration placeholder for production deployment


### PR DESCRIPTION
## Summary
- replace bare semicolon placeholder migrations with noop comments to ensure postgres compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e558ad723c83258950919abb52b951