### PR TITLE
Fix org slug usage in tasks endpoint context resolution

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -3586,7 +3586,7 @@ async def list_tasks(
     engagement: Optional[str] = Query(default=None, alias="engagementId"),
     auth: Dict[str, Any] = Depends(require_auth),
 ) -> Dict[str, Any]:
-    context = await resolve_org_context(auth["sub"], org_slug_form)
+    context = await resolve_org_context(auth["sub"], org_slug)
 
     if status and status not in TASK_STATUS_VALUES and status != "all":
         raise HTTPException(status_code=400, detail="invalid status filter")


### PR DESCRIPTION
## Summary
- align the /v1/tasks handler with the orgSlug query parameter when resolving the organisation context to avoid NameError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e558a2e34c832580b795d2e93e07a1