### PR TITLE
Add Express gateway middleware, SSE agent chat, and RAG proxies

### DIFF
--- a/apps/gateway/api-key.js
+++ b/apps/gateway/api-key.js
@@ -1,0 +1,57 @@
+import { logError, logWarn } from './logger.js';
+
+const HEADER_CANDIDATES = ['x-api-key', 'x-api-key'.toLowerCase()];
+
+function normaliseKeys(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw.map((value) => value.trim()).filter(Boolean);
+  }
+  return String(raw)
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export function createApiKeyValidator({ apiKeys }) {
+  const allowedKeys = new Set(normaliseKeys(apiKeys));
+
+  if (!allowedKeys.size) {
+    logWarn('gateway.api_key_unconfigured');
+    return function skipApiKeyValidation(_req, _res, next) {
+      next();
+    };
+  }
+
+  return function validateApiKey(req, res, next) {
+    const headerKey = HEADER_CANDIDATES.reduce((acc, header) => {
+      if (acc) return acc;
+      const value = req.headers[header];
+      return typeof value === 'string' ? value.trim() : acc;
+    }, '');
+
+    let candidate = headerKey;
+    if (!candidate) {
+      const authHeader = req.headers.authorization;
+      if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+        candidate = authHeader.slice(7).trim();
+      }
+    }
+
+    if (!candidate) {
+      logWarn('gateway.api_key_missing', { requestId: req.requestId, path: req.path });
+      return res.status(401).json({ error: 'missing_api_key' });
+    }
+
+    if (!allowedKeys.has(candidate)) {
+      logError('gateway.api_key_invalid', new Error('unauthorised'), {
+        requestId: req.requestId,
+        path: req.path,
+      });
+      return res.status(403).json({ error: 'invalid_api_key' });
+    }
+
+    req.apiKey = candidate;
+    next();
+  };
+}

--- a/apps/gateway/idempotency-middleware.js
+++ b/apps/gateway/idempotency-middleware.js
@@ -1,0 +1,78 @@
+import { logError, logInfo } from './logger.js';
+
+const IDEMPOTENCY_HEADERS = ['x-idempotency-key', 'idempotency-key'];
+
+function resolveKey(req) {
+  for (const header of IDEMPOTENCY_HEADERS) {
+    const value = req.headers[header];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function resolveResource(req, resource) {
+  if (typeof resource === 'function') {
+    return resource(req);
+  }
+  if (typeof resource === 'string' && resource.trim()) {
+    return resource.trim();
+  }
+  return `${req.method.toUpperCase()} ${req.path}`;
+}
+
+export function createIdempotencyMiddleware(store, options = {}) {
+  return async function idempotencyHandler(req, res, next) {
+    const key = resolveKey(req);
+    if (!key || !req.orgId) {
+      return next();
+    }
+
+    const resource = resolveResource(req, options.resource);
+
+    try {
+      const existing = await store?.find({ orgId: req.orgId, resource, key });
+      if (existing) {
+        res.setHeader('X-Idempotency-Key', key);
+        res.setHeader('X-Idempotency-Cache', 'HIT');
+        if (existing.requestId) {
+          res.setHeader('X-Replayed-From-Request', existing.requestId);
+        }
+        return res.status(existing.statusCode ?? 200).json(existing.response ?? {});
+      }
+    } catch (error) {
+      logError('gateway.idempotency_lookup_exception', error, { resource, orgId: req.orgId, requestId: req.requestId });
+    }
+
+    res.setHeader('X-Idempotency-Key', key);
+
+    const originalJson = res.json.bind(res);
+    res.json = function patchedJson(body) {
+      res.json = originalJson;
+      const statusCode = res.statusCode || 200;
+      if (statusCode >= 200 && statusCode < 500) {
+        store
+          ?.store({
+            orgId: req.orgId,
+            resource,
+            key,
+            statusCode,
+            response: body,
+            requestId: req.requestId,
+          })
+          .catch((error) => {
+            logError('gateway.idempotency_store_exception', error, {
+              resource,
+              orgId: req.orgId,
+              requestId: req.requestId,
+            });
+          });
+      }
+      return originalJson(body);
+    };
+
+    logInfo('gateway.idempotency_pending', { orgId: req.orgId, resource, requestId: req.requestId });
+    return next();
+  };
+}

--- a/apps/gateway/idempotency-store.js
+++ b/apps/gateway/idempotency-store.js
@@ -1,0 +1,68 @@
+import { Pool } from 'pg';
+import { logError, logInfo, logWarn } from './logger.js';
+
+function createPool(connectionString) {
+  if (!connectionString) {
+    logWarn('gateway.idempotency_unconfigured');
+    return null;
+  }
+  const pool = new Pool({ connectionString });
+  pool.on('error', (error) => {
+    logError('gateway.idempotency_pool_error', error);
+  });
+  return pool;
+}
+
+export function createIdempotencyStore(connectionString) {
+  const pool = createPool(connectionString);
+
+  async function find({ orgId, resource, key }) {
+    if (!pool) return null;
+    try {
+      const { rows } = await pool.query(
+        'SELECT status_code, response, request_id FROM idempotency_keys WHERE org_id = $1 AND resource = $2 AND idempotency_key = $3 LIMIT 1',
+        [orgId, resource, key],
+      );
+      if (!rows.length) {
+        return null;
+      }
+      const row = rows[0];
+      return {
+        statusCode: row.status_code ?? 200,
+        response: row.response ?? {},
+        requestId: row.request_id ?? null,
+      };
+    } catch (error) {
+      logError('gateway.idempotency_lookup_failed', error, { orgId, resource });
+      return null;
+    }
+  }
+
+  async function store({ orgId, resource, key, statusCode, response, requestId }) {
+    if (!pool) return;
+    try {
+      await pool.query(
+        `INSERT INTO idempotency_keys (org_id, resource, idempotency_key, status_code, response, request_id)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+         ON CONFLICT (org_id, resource, idempotency_key)
+         DO UPDATE SET status_code = EXCLUDED.status_code, response = EXCLUDED.response, request_id = EXCLUDED.request_id`,
+        [orgId, resource, key, statusCode, JSON.stringify(response ?? {}), requestId ?? null],
+      );
+      logInfo('gateway.idempotency_stored', { orgId, resource, requestId });
+    } catch (error) {
+      logError('gateway.idempotency_store_failed', error, { orgId, resource, requestId });
+    }
+  }
+
+  async function destroy() {
+    if (pool) {
+      await pool.end();
+    }
+  }
+
+  return {
+    find,
+    store,
+    destroy,
+  };
+}

--- a/apps/gateway/logger.js
+++ b/apps/gateway/logger.js
@@ -1,0 +1,86 @@
+const SENSITIVE_KEYS = new Set(['authorization', 'api-key', 'api_key', 'token', 'password', 'secret']);
+
+function scrubValue(value) {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    if (trimmed.length > 200) {
+      return `${trimmed.slice(0, 197)}...`;
+    }
+    return trimmed;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (value instanceof Error) {
+    return { message: value.message, stack: value.stack };
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map((entry) => scrubValue(entry)).filter((entry) => entry !== undefined);
+  }
+  if (typeof value === 'object') {
+    const output = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+        continue;
+      }
+      const scrubbed = scrubValue(entry);
+      if (scrubbed !== undefined) {
+        output[key] = scrubbed;
+      }
+    }
+    return output;
+  }
+  return undefined;
+}
+
+function scrubMeta(meta = {}) {
+  const clean = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      continue;
+    }
+    const scrubbed = scrubValue(value);
+    if (scrubbed !== undefined) {
+      clean[key] = scrubbed;
+    }
+  }
+  return clean;
+}
+
+export function logInfo(event, meta = {}) {
+  const payload = {
+    level: 'info',
+    event,
+    ...scrubMeta(meta),
+    timestamp: new Date().toISOString(),
+  };
+  console.log(JSON.stringify(payload));
+}
+
+export function logWarn(event, meta = {}) {
+  const payload = {
+    level: 'warn',
+    event,
+    ...scrubMeta(meta),
+    timestamp: new Date().toISOString(),
+  };
+  console.warn(JSON.stringify(payload));
+}
+
+export function logError(event, error, meta = {}) {
+  const payload = {
+    level: 'error',
+    event,
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+    ...scrubMeta(meta),
+    timestamp: new Date().toISOString(),
+  };
+  console.error(JSON.stringify(payload));
+}

--- a/apps/gateway/org-guard.js
+++ b/apps/gateway/org-guard.js
@@ -1,0 +1,25 @@
+import { logWarn } from './logger.js';
+
+const ORG_ID_HEADER = 'x-org-id';
+const ORG_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidOrgId(value) {
+  return typeof value === 'string' && ORG_ID_PATTERN.test(value.trim());
+}
+
+export function createOrgGuard() {
+  return function orgGuard(req, res, next) {
+    const rawOrgId = req.headers[ORG_ID_HEADER];
+    if (Array.isArray(rawOrgId)) {
+      return res.status(400).json({ error: 'invalid_org_id_header' });
+    }
+    if (!rawOrgId || !isValidOrgId(rawOrgId)) {
+      logWarn('gateway.org_guard_missing', { requestId: req.requestId, path: req.path });
+      return res.status(400).json({ error: 'invalid_org_id' });
+    }
+
+    req.orgId = rawOrgId.trim();
+    res.locals.orgId = req.orgId;
+    return next();
+  };
+}

--- a/apps/gateway/rate-limit.js
+++ b/apps/gateway/rate-limit.js
@@ -1,0 +1,69 @@
+import Redis from 'ioredis';
+import { logError, logInfo, logWarn } from './logger.js';
+
+function createRedisClient(connectionString) {
+  if (!connectionString) {
+    logWarn('gateway.redis_unconfigured');
+    return null;
+  }
+  const client = new Redis(connectionString, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+
+  client.on('error', (error) => {
+    logError('gateway.redis_error', error);
+  });
+
+  client.connect().catch((error) => {
+    logError('gateway.redis_connect_failed', error);
+  });
+
+  return client;
+}
+
+export function createRateLimiter({ redisUrl, defaultLimit = 60, defaultWindowSeconds = 60 }) {
+  const redis = createRedisClient(redisUrl);
+
+  return function rateLimiter(options = {}) {
+    const limit = Number.isFinite(options.limit) ? Number(options.limit) : defaultLimit;
+    const windowSeconds = Number.isFinite(options.windowSeconds) ? Number(options.windowSeconds) : defaultWindowSeconds;
+    const resource = options.resource ?? 'default';
+
+    return async function enforceRateLimit(req, res, next) {
+      if (!redis) {
+        return next();
+      }
+
+      const orgId = req.orgId ?? 'anonymous';
+      const key = `gateway:rate:${resource}:${orgId}`;
+
+      try {
+        const count = await redis.incr(key);
+        if (count === 1) {
+          await redis.expire(key, windowSeconds);
+        }
+        const ttl = await redis.ttl(key);
+        const remaining = Math.max(0, limit - count);
+
+        res.setHeader('X-RateLimit-Limit', String(limit));
+        res.setHeader('X-RateLimit-Remaining', String(Math.max(0, remaining)));
+        if (ttl > 0) {
+          res.setHeader('X-RateLimit-Reset', String(Math.floor(Date.now() / 1000) + ttl));
+        }
+
+        if (count > limit) {
+          const retryAfter = ttl > 0 ? ttl : windowSeconds;
+          logInfo('gateway.rate_limited', { orgId, resource, requestId: req.requestId });
+          res.setHeader('Retry-After', String(retryAfter));
+          return res.status(429).json({ error: 'rate_limit_exceeded', retryAfterSeconds: retryAfter });
+        }
+
+        return next();
+      } catch (error) {
+        logError('gateway.rate_limit_error', error, { resource, orgId, requestId: req.requestId });
+        return next();
+      }
+    };
+  };
+}

--- a/apps/gateway/request-context.js
+++ b/apps/gateway/request-context.js
@@ -1,0 +1,37 @@
+import { randomUUID, randomBytes } from 'node:crypto';
+
+const TRACEPARENT_HEADER = 'traceparent';
+const TRACESTATE_HEADER = 'tracestate';
+
+function isValidTraceparent(value) {
+  return typeof value === 'string' && /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/i.test(value.trim());
+}
+
+function generateTraceparent() {
+  const traceId = randomUUID().replace(/-/g, '');
+  const spanId = randomBytes(8).toString('hex');
+  return `00-${traceId}-${spanId}-01`;
+}
+
+export function requestContextMiddleware(req, res, next) {
+  const incomingRequestId = (req.headers['x-request-id'] || req.headers['X-Request-Id']) ?? '';
+  const requestId = typeof incomingRequestId === 'string' && incomingRequestId.trim()
+    ? incomingRequestId.trim()
+    : randomUUID();
+
+  req.requestId = requestId;
+  res.setHeader('X-Request-ID', requestId);
+
+  const candidateTraceparent = req.headers[TRACEPARENT_HEADER];
+  const traceparent = isValidTraceparent(candidateTraceparent) ? candidateTraceparent.trim() : generateTraceparent();
+  req.traceparent = traceparent;
+  res.setHeader('Traceparent', traceparent);
+
+  const tracestate = req.headers[TRACESTATE_HEADER];
+  if (typeof tracestate === 'string' && tracestate.trim()) {
+    req.tracestate = tracestate.trim();
+    res.setHeader('Tracestate', tracestate.trim());
+  }
+
+  next();
+}

--- a/apps/gateway/routes/agent.js
+++ b/apps/gateway/routes/agent.js
@@ -1,0 +1,105 @@
+import { logError, logInfo, logWarn } from '../logger.js';
+
+function buildAgentUrl(baseUrl) {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    if (!url.pathname || url.pathname === '/' || url.pathname === '') {
+      url.pathname = '/v1/chat';
+    }
+    return url;
+  } catch (error) {
+    logError('gateway.agent_url_invalid', error, { baseUrl });
+    return null;
+  }
+}
+
+function forwardHeaders(req, extra = {}) {
+  const headers = {
+    'x-request-id': req.requestId,
+    'x-org-id': req.orgId,
+    traceparent: req.traceparent,
+    ...extra,
+  };
+  if (req.tracestate) {
+    headers.tracestate = req.tracestate;
+  }
+  return headers;
+}
+
+export function registerAgentRoutes(app, { agentServiceUrl, agentServiceApiKey, rateLimiter }) {
+  const upstream = buildAgentUrl(agentServiceUrl);
+
+  const rateLimitMiddleware = typeof rateLimiter === 'function'
+    ? rateLimiter({ resource: 'agent:chat', limit: 30, windowSeconds: 60 })
+    : (_req, _res, next) => next();
+
+  app.get('/v1/agent/chat', rateLimitMiddleware, async (req, res) => {
+    if (!upstream) {
+      logWarn('gateway.agent_unavailable', { requestId: req.requestId });
+      return res.status(503).json({ error: 'agent_service_unavailable' });
+    }
+
+    logInfo('gateway.agent_chat_start', { orgId: req.orgId, requestId: req.requestId });
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders?.();
+
+    const controller = new AbortController();
+    const heartbeat = setInterval(() => {
+      res.write(`: keep-alive ${Date.now()}\n\n`);
+    }, 15000);
+
+    const upstreamHeaders = forwardHeaders(req);
+    if (agentServiceApiKey) {
+      upstreamHeaders.authorization = `Bearer ${agentServiceApiKey}`;
+    }
+
+    try {
+      const upstreamResponse = await fetch(upstream, {
+        method: 'GET',
+        headers: upstreamHeaders,
+        signal: controller.signal,
+      });
+
+      if (!upstreamResponse.ok || !upstreamResponse.body) {
+        clearInterval(heartbeat);
+        logError('gateway.agent_upstream_error', new Error(`status ${upstreamResponse.status}`), {
+          requestId: req.requestId,
+          status: upstreamResponse.status,
+        });
+        return res.status(502).json({ error: 'agent_service_error' });
+      }
+
+      const reader = upstreamResponse.body.getReader();
+      req.on('close', () => {
+        controller.abort();
+        clearInterval(heartbeat);
+        reader.cancel().catch(() => {});
+      });
+
+      while (true) { // eslint-disable-line no-constant-condition
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          res.write(Buffer.from(value));
+        }
+      }
+
+      clearInterval(heartbeat);
+      res.end();
+      logInfo('gateway.agent_chat_complete', { orgId: req.orgId, requestId: req.requestId });
+      return undefined;
+    } catch (error) {
+      clearInterval(heartbeat);
+      logError('gateway.agent_chat_failed', error, { orgId: req.orgId, requestId: req.requestId });
+      if (!res.headersSent) {
+        return res.status(502).json({ error: 'agent_service_error' });
+      }
+      res.end();
+      return undefined;
+    }
+  });
+}

--- a/apps/gateway/routes/rag.js
+++ b/apps/gateway/routes/rag.js
@@ -1,0 +1,156 @@
+import multer from 'multer';
+import { logError, logInfo } from '../logger.js';
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 25 * 1024 * 1024 } });
+
+function buildRagUrl(baseUrl, path) {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    url.pathname = path;
+    return url.toString();
+  } catch (error) {
+    logError('gateway.rag_url_invalid', error, { baseUrl, path });
+    return null;
+  }
+}
+
+function toJsonResponse(res, upstreamResponse) {
+  return upstreamResponse
+    .json()
+    .then((body) => {
+      res.status(upstreamResponse.status).json(body);
+    })
+    .catch(async (error) => {
+      logError('gateway.rag_invalid_json', error, { status: upstreamResponse.status });
+      const text = await upstreamResponse.text();
+      res.status(502).json({ error: 'rag_service_error', detail: text.slice(0, 200) });
+    });
+}
+
+function forwardHeaders(req, apiKey) {
+  const headers = {
+    'x-request-id': req.requestId,
+    'x-org-id': req.orgId,
+    traceparent: req.traceparent,
+    'content-type': 'application/json',
+  };
+  if (req.tracestate) {
+    headers.tracestate = req.tracestate;
+  }
+  if (apiKey) {
+    headers.authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+export function registerRagRoutes(app, { ragServiceUrl, ragServiceApiKey, rateLimiter, idempotencyMiddlewareFactory }) {
+  const ingestUrl = buildRagUrl(ragServiceUrl, '/v1/rag/ingest');
+  const searchUrl = buildRagUrl(ragServiceUrl, '/v1/rag/search');
+
+  app.post(
+    '/v1/rag/ingest',
+    upload.single('file'),
+    rateLimiter({ resource: 'rag:ingest', limit: 30, windowSeconds: 60 }),
+    idempotencyMiddlewareFactory({ resource: 'rag:ingest' }),
+    async (req, res) => {
+      if (!ingestUrl) {
+        return res.status(503).json({ error: 'rag_service_unavailable' });
+      }
+
+      const file = req.file;
+      const orgSlug = typeof req.body?.orgSlug === 'string' ? req.body.orgSlug.trim() : '';
+      const documentId = typeof req.body?.documentId === 'string' ? req.body.documentId.trim() : '';
+
+      if (!file) {
+        return res.status(400).json({ error: 'file_required' });
+      }
+      if (file.mimetype !== 'application/pdf') {
+        return res.status(400).json({ error: 'unsupported_media_type' });
+      }
+      if (!orgSlug) {
+        return res.status(400).json({ error: 'org_slug_required' });
+      }
+
+      const formData = new FormData();
+      formData.set('orgSlug', orgSlug);
+      if (documentId) {
+        formData.set('documentId', documentId);
+      }
+      formData.set('file', new Blob([file.buffer], { type: file.mimetype }), file.originalname);
+
+      const headers = forwardHeaders(req, ragServiceApiKey);
+      delete headers['content-type'];
+
+      try {
+        const response = await fetch(ingestUrl, {
+          method: 'POST',
+          headers,
+          body: formData,
+        });
+
+        if (!response.ok) {
+          logError('gateway.rag_ingest_failed', new Error(`status ${response.status}`), {
+            requestId: req.requestId,
+            status: response.status,
+          });
+          const detail = await response.text();
+          return res.status(502).json({ error: 'rag_service_error', detail: detail.slice(0, 200) });
+        }
+
+        const result = await response.json();
+        logInfo('gateway.rag_ingest_forwarded', { orgId: req.orgId, requestId: req.requestId });
+        return res.status(200).json(result);
+      } catch (error) {
+        logError('gateway.rag_ingest_exception', error, { orgId: req.orgId, requestId: req.requestId });
+        return res.status(502).json({ error: 'rag_service_error' });
+      }
+    },
+  );
+
+  app.post(
+    '/v1/rag/search',
+    rateLimiter({ resource: 'rag:search', limit: 60, windowSeconds: 60 }),
+    idempotencyMiddlewareFactory({ resource: 'rag:search' }),
+    async (req, res) => {
+      if (!searchUrl) {
+        return res.status(503).json({ error: 'rag_service_unavailable' });
+      }
+
+      const query = typeof req.body?.query === 'string' ? req.body.query.trim() : '';
+      const topK = Number.isFinite(req.body?.topK) ? Number(req.body.topK) : undefined;
+
+      if (!query) {
+        return res.status(400).json({ error: 'query_required' });
+      }
+
+      const payload = { query };
+      if (Number.isFinite(topK) && topK > 0) {
+        payload.topK = Math.min(Math.floor(topK), 50);
+      }
+
+      try {
+        const response = await fetch(searchUrl, {
+          method: 'POST',
+          headers: forwardHeaders(req, ragServiceApiKey),
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          logError('gateway.rag_search_failed', new Error(`status ${response.status}`), {
+            requestId: req.requestId,
+            status: response.status,
+          });
+          return toJsonResponse(res, response);
+        }
+
+        const data = await response.json();
+        logInfo('gateway.rag_search_forwarded', { orgId: req.orgId, requestId: req.requestId });
+        return res.status(200).json(data);
+      } catch (error) {
+        logError('gateway.rag_search_exception', error, { orgId: req.orgId, requestId: req.requestId });
+        return res.status(502).json({ error: 'rag_service_error' });
+      }
+    },
+  );
+}

--- a/apps/gateway/server.js
+++ b/apps/gateway/server.js
@@ -1,0 +1,64 @@
+import express from 'express';
+import { requestContextMiddleware } from './request-context.js';
+import { createOrgGuard } from './org-guard.js';
+import { createApiKeyValidator } from './api-key.js';
+import { createRateLimiter } from './rate-limit.js';
+import { createIdempotencyStore } from './idempotency-store.js';
+import { createIdempotencyMiddleware } from './idempotency-middleware.js';
+import { registerAgentRoutes } from './routes/agent.js';
+import { registerRagRoutes } from './routes/rag.js';
+import { logInfo } from './logger.js';
+
+const JSON_LIMIT = '5mb';
+
+export function createGatewayServer() {
+  const app = express();
+  app.disable('x-powered-by');
+
+  app.use(express.json({ limit: JSON_LIMIT }));
+  app.use(express.urlencoded({ extended: true }));
+  app.use(requestContextMiddleware);
+
+  const orgGuard = createOrgGuard();
+  const apiKeys = process.env.GATEWAY_API_KEYS || process.env.API_KEYS || '';
+  const apiKeyValidator = createApiKeyValidator({ apiKeys });
+  const rateLimiterFactory = createRateLimiter({ redisUrl: process.env.REDIS_URL, defaultLimit: 60, defaultWindowSeconds: 60 });
+  const idempotencyStore = createIdempotencyStore(process.env.DATABASE_URL);
+  const idempotencyFactory = (options) => createIdempotencyMiddleware(idempotencyStore, options);
+
+  app.get('/health', async (req, res) => {
+    const health = {
+      status: 'ok',
+      requestId: req.requestId,
+      redis: process.env.REDIS_URL ? 'configured' : 'disabled',
+      idempotency: process.env.DATABASE_URL ? 'configured' : 'disabled',
+    };
+    res.json(health);
+  });
+
+  app.use('/v1', orgGuard, apiKeyValidator);
+
+  registerAgentRoutes(app, {
+    agentServiceUrl: process.env.AGENT_SERVICE_URL,
+    agentServiceApiKey: process.env.AGENT_SERVICE_API_KEY,
+    rateLimiter: rateLimiterFactory,
+  });
+
+  registerRagRoutes(app, {
+    ragServiceUrl: process.env.RAG_SERVICE_URL,
+    ragServiceApiKey: process.env.RAG_SERVICE_API_KEY,
+    rateLimiter: rateLimiterFactory,
+    idempotencyMiddlewareFactory: idempotencyFactory,
+  });
+
+  app.use((req, res) => {
+    res.status(404).json({ error: 'not_found' });
+  });
+
+  app.use((error, req, res, _next) => {
+    logInfo('gateway.unhandled_error', { requestId: req.requestId, error: error?.message });
+    res.status(500).json({ error: 'internal_error' });
+  });
+
+  return app;
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,26 @@
+import { createGatewayServer } from './apps/gateway/server.js';
+import { logError, logInfo } from './apps/gateway/logger.js';
+
+const port = Number.parseInt(process.env.PORT ?? '3000', 10);
+
+async function start() {
+  try {
+    const app = await createGatewayServer();
+    app.listen(port, () => {
+      logInfo('gateway.started', { port });
+    });
+  } catch (error) {
+    logError('gateway.start_failed', error);
+    process.exitCode = 1;
+  }
+}
+
+process.on('uncaughtException', (error) => {
+  logError('gateway.uncaught_exception', error);
+});
+
+process.on('unhandledRejection', (reason) => {
+  logError('gateway.unhandled_rejection', reason instanceof Error ? reason : new Error(String(reason)));
+});
+
+await start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "express": "^4.19.2",
         "framer-motion": "^12.23.12",
         "input-otp": "^1.4.2",
+        "ioredis": "^5.4.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.462.0",
         "multer": "^2.0.0",
@@ -2573,6 +2574,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -6399,6 +6406,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -6938,6 +6954,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -8725,6 +8750,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
+      "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.4.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -9624,10 +9673,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -11320,6 +11381,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -12063,6 +12145,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express": "^4.19.2",
     "framer-motion": "^12.23.12",
     "input-otp": "^1.4.2",
+    "ioredis": "^5.4.1",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.462.0",
     "multer": "^2.0.0",

--- a/tests/gateway/middleware.test.ts
+++ b/tests/gateway/middleware.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createOrgGuard } from '../../apps/gateway/org-guard.js';
+import { createApiKeyValidator } from '../../apps/gateway/api-key.js';
+import { createIdempotencyMiddleware } from '../../apps/gateway/idempotency-middleware.js';
+
+describe('OrgGuard', () => {
+  function createResponse() {
+    return {
+      statusCode: 200,
+      locals: {},
+      status: vi.fn(function (code: number) {
+        this.statusCode = code;
+        return this;
+      }),
+      json: vi.fn(function (body: unknown) {
+        this.body = body;
+        return this;
+      }),
+    } as any;
+  }
+
+  it('rejects missing organisation identifier', () => {
+    const guard = createOrgGuard();
+    const req: any = { headers: {}, requestId: 'req-1', path: '/resource' };
+    const res = createResponse();
+    const next = vi.fn();
+
+    guard(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'invalid_org_id' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows valid organisation identifier', () => {
+    const guard = createOrgGuard();
+    const orgId = '11111111-2222-3333-4444-555555555555';
+    const req: any = { headers: { 'x-org-id': orgId }, requestId: 'req-2', path: '/resource' };
+    const res = createResponse();
+    const next = vi.fn();
+
+    guard(req, res, next);
+
+    expect(req.orgId).toBe(orgId);
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('API key validator', () => {
+  function createResponse() {
+    return {
+      statusCode: 200,
+      locals: {},
+      status: vi.fn(function (code: number) {
+        this.statusCode = code;
+        return this;
+      }),
+      json: vi.fn(function (body: unknown) {
+        this.body = body;
+        return this;
+      }),
+    } as any;
+  }
+
+  it('rejects requests without API key', () => {
+    const validator = createApiKeyValidator({ apiKeys: ['secret'] });
+    const req: any = { headers: {}, requestId: 'req-3', path: '/secure' };
+    const res = createResponse();
+    const next = vi.fn();
+
+    validator(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'missing_api_key' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('accepts configured API key', () => {
+    const validator = createApiKeyValidator({ apiKeys: ['secret'] });
+    const req: any = { headers: { 'x-api-key': 'secret' }, requestId: 'req-4', path: '/secure' };
+    const res = createResponse();
+    const next = vi.fn();
+
+    validator(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.apiKey).toBe('secret');
+  });
+});
+
+describe('Idempotency middleware', () => {
+  function createResponse() {
+    return {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      locals: {},
+      status: vi.fn(function (code: number) {
+        this.statusCode = code;
+        return this;
+      }),
+      json: vi.fn(function (body: unknown) {
+        this.body = body;
+        return this;
+      }),
+      setHeader: vi.fn(function (key: string, value: string) {
+        this.headers[key] = value;
+      }),
+    } as any;
+  }
+
+  it('returns cached response when available', async () => {
+    const store = {
+      find: vi.fn().mockResolvedValue({ statusCode: 201, response: { ok: true }, requestId: 'req-old' }),
+      store: vi.fn(),
+    };
+    const middleware = createIdempotencyMiddleware(store as any, { resource: 'tests:cached' });
+
+    const req: any = {
+      headers: { 'x-idempotency-key': 'abc123' },
+      orgId: '11111111-2222-3333-4444-555555555555',
+      method: 'POST',
+      path: '/tests',
+      requestId: 'req-5',
+    };
+    const res = createResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('stores new responses on success', async () => {
+    const store = {
+      find: vi.fn().mockResolvedValue(null),
+      store: vi.fn().mockResolvedValue(undefined),
+    };
+    const middleware = createIdempotencyMiddleware(store as any, { resource: 'tests:new' });
+
+    const req: any = {
+      headers: { 'x-idempotency-key': 'cache-key' },
+      orgId: '11111111-2222-3333-4444-555555555555',
+      method: 'POST',
+      path: '/tests',
+      requestId: 'req-6',
+    };
+    const res = createResponse();
+
+    const next = vi.fn(() => {
+      res.status(202);
+      res.json({ ok: true });
+    });
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(store.store).toHaveBeenCalledWith({
+      orgId: req.orgId,
+      resource: 'tests:new',
+      key: 'cache-key',
+      statusCode: 202,
+      response: { ok: true },
+      requestId: 'req-6',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an Express-based gateway entrypoint with request context, organisation guard, API key validation, Redis-backed rate limiting, and idempotency storage
- proxy agent chat over SSE and forward RAG ingest/search traffic with validation, trace propagation, and scrubbed logging
- cover the core middleware behaviours with Vitest

## Testing
- npx vitest run tests/gateway/middleware.test.ts --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68aae3ebf51c832587989f3f88feb872