### PR TITLE
feat: add hardened gateway middlewares

### DIFF
--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -1,0 +1,18 @@
+# Gateway Service
+
+This directory contains the Express-based gateway responsible for enforcing
+multi-tenant controls before requests reach downstream services. Key features:
+
+- **OrgGuard** – validates organisation scope and role membership from request
+  headers before exposing `/v1` routes.
+- **Redis-backed token bucket** (with an in-memory fallback) to rate limit
+  per-org/per-user traffic.
+- **Idempotency store** that caches successful responses when callers send an
+  `X-Idempotency-Key` header.
+- **Trace propagation** via `X-Request-ID` and `X-Trace-ID` headers bound to an
+  async request context.
+- **PII scrubbing** for structured request/response logs, preventing sensitive
+  data from leaking into log drains.
+
+Use `createGatewayServer()` from `src/server.ts` to embed the service or run it
+as a standalone process with `node apps/gateway/src/server.ts`.

--- a/apps/gateway/src/middleware/idempotency.ts
+++ b/apps/gateway/src/middleware/idempotency.ts
@@ -1,0 +1,92 @@
+import type { Request, RequestHandler, Response } from 'express';
+import { getRequestContext } from '../utils/request-context';
+
+export interface IdempotencyStore {
+  get(key: string): Promise<{ status: number; body: unknown } | null>;
+  set(key: string, value: { status: number; body: unknown }, ttlMs: number): Promise<void>;
+}
+
+type CacheEntry = { status: number; body: unknown; expiresAt: number };
+
+class InMemoryIdempotencyStore implements IdempotencyStore {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  async get(key: string): Promise<{ status: number; body: unknown } | null> {
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+    return { status: entry.status, body: entry.body };
+  }
+
+  async set(key: string, value: { status: number; body: unknown }, ttlMs: number): Promise<void> {
+    this.entries.set(key, { ...value, expiresAt: Date.now() + ttlMs });
+  }
+}
+
+const DEFAULT_HEADERS = ['x-idempotency-key', 'idempotency-key'];
+
+export type IdempotencyOptions = {
+  store?: IdempotencyStore;
+  ttlMs?: number;
+  headerNames?: string[];
+  scopeResolver?: (req: Request, res: Response) => string;
+};
+
+function pickKey(req: Request, headers: string[]): string | null {
+  for (const header of headers) {
+    const value = req.headers[header];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+export function createIdempotencyMiddleware(options: IdempotencyOptions = {}): RequestHandler {
+  const ttlMs = options.ttlMs ?? 10 * 60 * 1000;
+  const headerNames = options.headerNames ?? DEFAULT_HEADERS;
+  const store = options.store ?? new InMemoryIdempotencyStore();
+  const resolveScope =
+    options.scopeResolver ?? ((req, res) => res.locals.org?.orgId ?? (req.headers['x-org-id'] as string) ?? 'global');
+
+  return async (req, res, next) => {
+    const key = pickKey(req, headerNames);
+    if (!key) {
+      return next();
+    }
+
+    const scope = resolveScope(req, res);
+    const compositeKey = `${scope}:${key}`;
+    try {
+      const cached = await store.get(compositeKey);
+      if (cached) {
+        const context = getRequestContext();
+        res.setHeader('x-idempotent-replay', 'true');
+        if (context?.requestId) {
+          res.setHeader('x-request-id', context.requestId);
+        }
+        return res.status(cached.status).json(cached.body);
+      }
+    } catch (error) {
+      console.warn('idempotency_lookup_failed', { error });
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = (body: unknown) => {
+      try {
+        const status = res.statusCode ?? 200;
+        store
+          .set(compositeKey, { status, body }, ttlMs)
+          .catch((error) => console.warn('idempotency_store_failed', { error }));
+      } catch (error) {
+        console.warn('idempotency_store_failed', { error });
+      }
+      return originalJson(body);
+    };
+
+    next();
+  };
+}

--- a/apps/gateway/src/middleware/org-guard.ts
+++ b/apps/gateway/src/middleware/org-guard.ts
@@ -1,0 +1,99 @@
+import type { RequestHandler } from 'express';
+import { bindOrgContext } from '../utils/request-context';
+
+const DEFAULT_ROLE_HIERARCHY = ['STAFF', 'MANAGER', 'PARTNER', 'SYSTEM_ADMIN'];
+
+export type OrgGuardOptions = {
+  minimumRole?: string;
+  roleHierarchy?: string[];
+};
+
+export type OrgContext = {
+  orgId: string;
+  userId: string;
+  role: string;
+};
+
+function parseMembershipHeader(headerValue: string | string[] | undefined): Record<string, string> {
+  if (!headerValue) return {};
+  const raw = Array.isArray(headerValue) ? headerValue.join(',') : headerValue;
+  const entries = raw.split(/[;,]/).map((entry) => entry.trim()).filter(Boolean);
+  const result: Record<string, string> = {};
+  for (const entry of entries) {
+    const [orgId, role] = entry.split(':', 2).map((part) => part.trim());
+    if (orgId && role) {
+      result[orgId] = role.toUpperCase();
+    }
+  }
+  return result;
+}
+
+function resolveOrgId(req: any): string | null {
+  const headerOrg = (req.headers['x-org-id'] as string | undefined)?.trim();
+  if (headerOrg) return headerOrg;
+  const paramOrg = (req.params?.orgId ?? req.params?.orgSlug ?? req.params?.org) as string | undefined;
+  if (paramOrg) return paramOrg;
+  if (req.body && typeof req.body === 'object') {
+    const bodyOrg = (req.body.orgId ?? req.body.orgSlug) as string | undefined;
+    if (bodyOrg) return String(bodyOrg);
+  }
+  return null;
+}
+
+function getUserId(req: any): string | null {
+  const header = (req.headers['x-user-id'] as string | undefined)?.trim();
+  if (header) return header;
+  if (req.user?.id) return String(req.user.id);
+  if (req.auth?.userId) return String(req.auth.userId);
+  return null;
+}
+
+function hasRequiredRole(role: string, minimumRole: string | undefined, hierarchy: string[]): boolean {
+  if (!minimumRole) return true;
+  const normalised = role.toUpperCase();
+  const target = minimumRole.toUpperCase();
+  const index = hierarchy.indexOf(normalised);
+  const minIndex = hierarchy.indexOf(target);
+  if (index === -1 || minIndex === -1) {
+    return normalised === target;
+  }
+  return index >= minIndex;
+}
+
+declare module 'express-serve-static-core' {
+  interface Response {
+    locals: {
+      org?: OrgContext;
+      [key: string]: unknown;
+    };
+  }
+}
+
+export function createOrgGuard(options: OrgGuardOptions = {}): RequestHandler {
+  const hierarchy = options.roleHierarchy ?? DEFAULT_ROLE_HIERARCHY;
+  return (req, res, next) => {
+    const orgId = resolveOrgId(req);
+    if (!orgId) {
+      return res.status(400).json({ error: 'org_id_missing' });
+    }
+
+    const userId = getUserId(req);
+    if (!userId) {
+      return res.status(401).json({ error: 'user_not_authenticated' });
+    }
+
+    const memberships = parseMembershipHeader(req.headers['x-org-memberships']);
+    const role = memberships[orgId];
+    if (!role) {
+      return res.status(403).json({ error: 'org_access_denied' });
+    }
+    if (!hasRequiredRole(role, options.minimumRole, hierarchy)) {
+      return res.status(403).json({ error: 'insufficient_role' });
+    }
+
+    const context: OrgContext = { orgId, userId, role };
+    res.locals.org = context;
+    bindOrgContext(orgId, userId);
+    next();
+  };
+}

--- a/apps/gateway/src/middleware/pii-scrubber.ts
+++ b/apps/gateway/src/middleware/pii-scrubber.ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from 'express';
+import { scrubPii } from '../utils/pii';
+import { getRequestContext } from '../utils/request-context';
+
+export type PiiScrubberOptions = {
+  logger?: Pick<typeof console, 'info' | 'warn' | 'error'>;
+  redactBody?: boolean;
+};
+
+export function createPiiScrubberMiddleware(options: PiiScrubberOptions = {}): RequestHandler {
+  const logger = options.logger ?? console;
+  const redactBody = options.redactBody ?? true;
+
+  return (req, res, next) => {
+    const start = Date.now();
+    const context = getRequestContext();
+    const baseLog = {
+      traceId: context?.traceId,
+      requestId: context?.requestId,
+      method: req.method,
+      path: req.originalUrl,
+    };
+
+    logger.info({ ...baseLog, event: 'gateway.request.received', body: redactBody ? scrubPii(req.body) : req.body });
+
+    res.on('finish', () => {
+      logger.info({
+        ...baseLog,
+        event: 'gateway.request.completed',
+        status: res.statusCode,
+        durationMs: Date.now() - start,
+      });
+    });
+
+    next();
+  };
+}

--- a/apps/gateway/src/middleware/rate-limit.ts
+++ b/apps/gateway/src/middleware/rate-limit.ts
@@ -1,0 +1,139 @@
+import type { Request, RequestHandler } from 'express';
+
+export interface RedisLikeClient {
+  eval<T = unknown>(script: string, options: { keys: string[]; arguments: Array<string | number> }): Promise<T>;
+}
+
+type ConsumeResult = { allowed: boolean; retryAfterMs?: number };
+
+interface TokenBucket {
+  consume(key: string): Promise<ConsumeResult>;
+}
+
+class InMemoryTokenBucket implements TokenBucket {
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private readonly windowMs: number;
+  private readonly buckets = new Map<string, { tokens: number; lastRefill: number }>();
+
+  constructor(capacity: number, windowMs: number) {
+    this.capacity = Math.max(1, capacity);
+    this.windowMs = Math.max(1000, windowMs);
+    this.refillPerMs = this.capacity / this.windowMs;
+  }
+
+  async consume(key: string): Promise<ConsumeResult> {
+    const now = Date.now();
+    const state = this.buckets.get(key) ?? { tokens: this.capacity, lastRefill: now };
+    const delta = now - state.lastRefill;
+    if (delta > 0) {
+      state.tokens = Math.min(this.capacity, state.tokens + delta * this.refillPerMs);
+      state.lastRefill = now;
+    }
+
+    if (state.tokens < 1) {
+      const deficit = 1 - state.tokens;
+      const waitMs = Math.ceil(deficit / this.refillPerMs);
+      this.buckets.set(key, state);
+      return { allowed: false, retryAfterMs: waitMs };
+    }
+
+    state.tokens -= 1;
+    this.buckets.set(key, state);
+    return { allowed: true };
+  }
+}
+
+class RedisTokenBucket implements TokenBucket {
+  private readonly capacity: number;
+  private readonly windowMs: number;
+  private readonly refillPerMs: number;
+  private readonly client: RedisLikeClient;
+
+  constructor(client: RedisLikeClient, capacity: number, windowMs: number) {
+    this.client = client;
+    this.capacity = Math.max(1, capacity);
+    this.windowMs = Math.max(1000, windowMs);
+    this.refillPerMs = this.capacity / this.windowMs;
+  }
+
+  async consume(key: string): Promise<ConsumeResult> {
+    const now = Date.now();
+    const result = await this.client.eval<[number, number]>(LUA_TOKEN_BUCKET_SCRIPT, {
+      keys: [key],
+      arguments: [this.capacity, this.refillPerMs, now, this.windowMs],
+    });
+    if (!result || !Array.isArray(result)) {
+      return { allowed: true };
+    }
+    const allowed = Number(result[0]) === 1;
+    const retryAfterMs = Number(result[1]);
+    if (allowed) {
+      return { allowed: true };
+    }
+    return { allowed: false, retryAfterMs: retryAfterMs > 0 ? retryAfterMs : this.windowMs };
+  }
+}
+
+const LUA_TOKEN_BUCKET_SCRIPT = `
+local capacity = tonumber(ARGV[1])
+local refillPerMs = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local windowMs = tonumber(ARGV[4])
+local bucket = redis.call('hmget', KEYS[1], 'tokens', 'timestamp')
+local tokens = tonumber(bucket[1])
+local lastRefill = tonumber(bucket[2])
+if tokens == nil then
+  tokens = capacity
+  lastRefill = now
+end
+if lastRefill == nil then
+  lastRefill = now
+end
+local delta = now - lastRefill
+if delta > 0 then
+  local refill = delta * refillPerMs
+  tokens = math.min(capacity, tokens + refill)
+  lastRefill = now
+end
+if tokens < 1 then
+  redis.call('hmset', KEYS[1], 'tokens', tokens, 'timestamp', lastRefill)
+  redis.call('pexpire', KEYS[1], windowMs)
+  local deficit = 1 - tokens
+  local wait = math.ceil(deficit / refillPerMs)
+  return {0, wait}
+end
+redis.call('hmset', KEYS[1], 'tokens', tokens - 1, 'timestamp', lastRefill)
+redis.call('pexpire', KEYS[1], windowMs)
+return {1, 0}
+`;
+
+export type RateLimitOptions = {
+  capacity: number;
+  windowMs: number;
+  keyGenerator?: (req: Request) => string;
+  redisClient?: RedisLikeClient | null;
+};
+
+export function createRateLimitMiddleware(options: RateLimitOptions): RequestHandler {
+  const keyGenerator =
+    options.keyGenerator ?? ((req) => `${req.method}:${req.baseUrl}${req.path}:${req.ip ?? 'unknown'}`);
+  const bucket: TokenBucket = options.redisClient
+    ? new RedisTokenBucket(options.redisClient, options.capacity, options.windowMs)
+    : new InMemoryTokenBucket(options.capacity, options.windowMs);
+
+  return async (req, res, next) => {
+    const key = keyGenerator(req);
+    try {
+      const result = await bucket.consume(key);
+      if (!result.allowed) {
+        const retrySeconds = Math.ceil((result.retryAfterMs ?? options.windowMs) / 1000);
+        res.setHeader('retry-after', String(retrySeconds));
+        return res.status(429).json({ error: 'rate_limit_exceeded', retryAfterSeconds: retrySeconds });
+      }
+    } catch (error) {
+      console.warn('rate_limit_fallback', { error });
+    }
+    next();
+  };
+}

--- a/apps/gateway/src/middleware/trace.ts
+++ b/apps/gateway/src/middleware/trace.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from 'express';
+import { createRequestId, createTraceId } from '../utils/ids';
+import { runWithRequestContext, setRequestContextValue } from '../utils/request-context';
+
+export const REQUEST_ID_HEADER = 'x-request-id';
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+export const TRACE_ID_HEADER = 'x-trace-id';
+
+export const traceMiddleware: RequestHandler = (req, res, next) => {
+  const incomingRequestId =
+    (req.headers[REQUEST_ID_HEADER] as string | undefined) ||
+    (req.headers[CORRELATION_ID_HEADER] as string | undefined);
+  const requestId = (incomingRequestId ?? '').trim() || createRequestId();
+  const traceId = (req.headers[TRACE_ID_HEADER] as string | undefined)?.trim() || createTraceId();
+
+  runWithRequestContext({ traceId, requestId }, () => {
+    res.setHeader(REQUEST_ID_HEADER, requestId);
+    res.setHeader(TRACE_ID_HEADER, traceId);
+    if (incomingRequestId && !req.headers[TRACE_ID_HEADER]) {
+      res.setHeader(CORRELATION_ID_HEADER, incomingRequestId);
+    }
+
+    res.on('finish', () => {
+      setRequestContextValue('requestId', requestId);
+      setRequestContextValue('traceId', traceId);
+    });
+
+    next();
+  });
+};

--- a/apps/gateway/src/routes/v1.ts
+++ b/apps/gateway/src/routes/v1.ts
@@ -1,0 +1,59 @@
+import { Router } from 'express';
+import { createOrgGuard } from '../middleware/org-guard';
+import { createIdempotencyMiddleware } from '../middleware/idempotency';
+import { createRateLimitMiddleware } from '../middleware/rate-limit';
+import { getRequestContext } from '../utils/request-context';
+import { scrubPii } from '../utils/pii';
+
+const router = Router();
+
+router.use(createOrgGuard());
+router.use(
+  createRateLimitMiddleware({
+    capacity: 60,
+    windowMs: 60_000,
+    keyGenerator: (req) => {
+      const org = (req.headers['x-org-id'] as string) ?? 'global';
+      const user = (req.headers['x-user-id'] as string) ?? 'anonymous';
+      return `${org}:${user}:${req.method}:${req.path}`;
+    },
+  }),
+);
+router.use(createIdempotencyMiddleware());
+
+router.get('/health', (_req, res) => {
+  const context = getRequestContext();
+  res.json({
+    status: 'ok',
+    requestId: context?.requestId ?? null,
+    traceId: context?.traceId ?? null,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+router.post('/echo', (req, res) => {
+  const context = getRequestContext();
+  const orgContext = res.locals.org;
+  res.status(200).json({
+    orgId: orgContext?.orgId ?? null,
+    userId: orgContext?.userId ?? null,
+    role: orgContext?.role ?? null,
+    requestId: context?.requestId ?? null,
+    traceId: context?.traceId ?? null,
+    payload: scrubPii(req.body),
+  });
+});
+
+router.post('/jobs', (req, res) => {
+  const context = getRequestContext();
+  const orgContext = res.locals.org;
+  const jobId = `${orgContext?.orgId ?? 'org'}:${Date.now()}`;
+  res.status(202).json({
+    jobId,
+    acceptedAt: new Date().toISOString(),
+    requestId: context?.requestId ?? null,
+    traceId: context?.traceId ?? null,
+  });
+});
+
+export default router;

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import type { ErrorRequestHandler } from 'express';
+import { pathToFileURL } from 'url';
+import { traceMiddleware } from './middleware/trace';
+import { createPiiScrubberMiddleware } from './middleware/pii-scrubber';
+import v1Router from './routes/v1';
+import { scrubPii } from './utils/pii';
+import { getRequestContext } from './utils/request-context';
+
+export function createGatewayServer() {
+  const app = express();
+
+  app.disable('x-powered-by');
+  app.use(express.json({ limit: '5mb' }));
+  app.use(traceMiddleware);
+  app.use(createPiiScrubberMiddleware());
+
+  app.get('/health', (_req, res) => {
+    const context = getRequestContext();
+    res.json({ status: 'ok', requestId: context?.requestId ?? null, traceId: context?.traceId ?? null });
+  });
+
+  app.use('/v1', v1Router);
+
+  const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
+    console.error('gateway.unhandled_error', scrubPii({ message: err?.message, stack: err?.stack }));
+    res.status(500).json({ error: 'internal_server_error' });
+  };
+  app.use(errorHandler);
+
+  return app;
+}
+
+const isEntrypoint = (() => {
+  try {
+    const currentUrl = new URL(import.meta.url);
+    const invoked = process.argv[1] ? pathToFileURL(process.argv[1]) : null;
+    return invoked ? currentUrl.href === invoked.href : false;
+  } catch {
+    return false;
+  }
+})();
+
+if (isEntrypoint) {
+  const app = createGatewayServer();
+  const port = Number(process.env.PORT ?? 3000);
+  app.listen(port, () => {
+    console.log(`Gateway listening on port ${port}`);
+  });
+}

--- a/apps/gateway/src/utils/ids.ts
+++ b/apps/gateway/src/utils/ids.ts
@@ -1,0 +1,17 @@
+import { randomUUID } from 'crypto';
+
+export function createRequestId(): string {
+  try {
+    return randomUUID();
+  } catch {
+    return `req_${Math.random().toString(36).slice(2, 12)}`;
+  }
+}
+
+export function createTraceId(): string {
+  try {
+    return randomUUID();
+  } catch {
+    return `trace_${Math.random().toString(36).slice(2, 12)}`;
+  }
+}

--- a/apps/gateway/src/utils/pii.ts
+++ b/apps/gateway/src/utils/pii.ts
@@ -1,0 +1,37 @@
+const SENSITIVE_KEY_PATTERN = /(email|phone|ssn|tax|passport|national|dob|birth|address|pii)/i;
+const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+const PHONE_PATTERN = /\+?\d[\d\s().-]{7,}/;
+const SSN_PATTERN = /\b\d{3}-\d{2}-\d{4}\b/;
+
+function redactScalar(value: unknown): unknown {
+  if (typeof value === 'string') {
+    if (EMAIL_PATTERN.test(value) || PHONE_PATTERN.test(value) || SSN_PATTERN.test(value)) {
+      return '[REDACTED]';
+    }
+  }
+  return value;
+}
+
+export function scrubPii<T>(payload: T): T {
+  if (payload === null || typeof payload !== 'object') {
+    return redactScalar(payload) as T;
+  }
+
+  if (Array.isArray(payload)) {
+    return payload.map(scrubPii) as unknown as T;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+    if (value && typeof value === 'object') {
+      result[key] = scrubPii(value);
+      continue;
+    }
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      result[key] = '[REDACTED]';
+      continue;
+    }
+    result[key] = redactScalar(value);
+  }
+  return result as T;
+}

--- a/apps/gateway/src/utils/request-context.ts
+++ b/apps/gateway/src/utils/request-context.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type RequestContext = {
+  traceId: string;
+  requestId: string;
+  orgId?: string;
+  userId?: string;
+};
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(context: RequestContext, callback: () => T): T {
+  return storage.run(context, callback);
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+export function setRequestContextValue<K extends keyof RequestContext>(key: K, value: RequestContext[K]): void {
+  const store = storage.getStore();
+  if (!store) return;
+  (store as RequestContext)[key] = value;
+}
+
+export function getRequestId(): string | undefined {
+  return storage.getStore()?.requestId;
+}
+
+export function getTraceId(): string | undefined {
+  return storage.getStore()?.traceId;
+}
+
+export function bindOrgContext(orgId: string, userId?: string) {
+  setRequestContextValue('orgId', orgId);
+  if (userId) {
+    setRequestContextValue('userId', userId);
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,5 +26,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "apps/gateway/src"]
 }


### PR DESCRIPTION
## Summary
- scaffold an Express gateway with trace propagation and PII-scrubbed logging
- add OrgGuard, Redis token bucket rate limiting, and idempotency middleware across /v1 routes
- expose health/echo/jobs endpoints and document gateway usage in a README

## Testing
- not run (npm install fails due to peer dependency conflict with lovable-tagger)


------
https://chatgpt.com/codex/tasks/task_e_68aadd60ff3c832584e0a45ea75b6c89