### PR TITLE
feat: improve offline queue management

### DIFF
--- a/src/hooks/use-offline-support.ts
+++ b/src/hooks/use-offline-support.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  getOfflineQueueSnapshot,
+  OFFLINE_QUEUE_STORAGE_KEY,
+  OFFLINE_QUEUE_UPDATED_EVENT,
+  processQueuedActions,
+  queueAction,
+  type QueuedOfflineAction,
+} from '@/utils/pwa';
+
+function readQueue(): QueuedOfflineAction[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    return getOfflineQueueSnapshot();
+  } catch {
+    return [];
+  }
+}
+
+export interface UseOfflineSupportOptions {
+  autoProcessOnReconnect?: boolean;
+}
+
+export interface UseOfflineSupportResult {
+  queue: QueuedOfflineAction[];
+  queueLength: number;
+  hasPendingActions: boolean;
+  enqueueAction: (action: string, data: unknown) => number;
+  processQueue: () => number;
+}
+
+export function useOfflineSupport({ autoProcessOnReconnect = false }: UseOfflineSupportOptions = {}): UseOfflineSupportResult {
+  const [queue, setQueue] = useState<QueuedOfflineAction[]>(() => readQueue());
+
+  const refreshQueue = useCallback(() => {
+    setQueue(readQueue());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleQueueUpdated: EventListener = () => {
+      refreshQueue();
+    };
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === OFFLINE_QUEUE_STORAGE_KEY) {
+        refreshQueue();
+      }
+    };
+
+    window.addEventListener(OFFLINE_QUEUE_UPDATED_EVENT, handleQueueUpdated);
+    window.addEventListener('storage', handleStorage);
+
+    let handleOnline: (() => void) | undefined;
+    if (autoProcessOnReconnect) {
+      handleOnline = () => {
+        processQueuedActions();
+        refreshQueue();
+      };
+      window.addEventListener('online', handleOnline);
+    }
+
+    return () => {
+      window.removeEventListener(OFFLINE_QUEUE_UPDATED_EVENT, handleQueueUpdated);
+      window.removeEventListener('storage', handleStorage);
+      if (handleOnline) {
+        window.removeEventListener('online', handleOnline);
+      }
+    };
+  }, [autoProcessOnReconnect, refreshQueue]);
+
+  const enqueue = useCallback(
+    (action: string, data: unknown) => {
+      const length = queueAction(action, data);
+      refreshQueue();
+      return length;
+    },
+    [refreshQueue],
+  );
+
+  const process = useCallback(() => {
+    const processed = processQueuedActions();
+    refreshQueue();
+    return processed;
+  }, [refreshQueue]);
+
+  const hasPendingActions = queue.length > 0;
+  const queueLength = queue.length;
+
+  return useMemo(
+    () => ({ queue, queueLength, hasPendingActions, enqueueAction: enqueue, processQueue: process }),
+    [enqueue, hasPendingActions, process, queue, queueLength],
+  );
+}


### PR DESCRIPTION
## Summary
- add offline queue constants, typed helpers, and custom events so queue writes notify listeners
- expose a reusable hook that tracks offline actions, supports enqueueing, and optionally processes on reconnect

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e587f70ff48325bf762c8e79f24e0c